### PR TITLE
London operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 # london-curriculum
 London curriculum information and discussions.
 
+Check out the updated calendar [here](https://calendar.google.com/calendar/embed?src=h7329vu9qpi64cli2sdk53l9ec@group.calendar.google.com&ctz=Europe/London).
+
 The curriculum committee spreadsheet, to be used at our meetings to record attendance and tally votes on proposals, can be found [here.](https://docs.google.com/spreadsheets/d/1_pqo-2Gzzba16rJYretpgZpgUx1GgkEv2-s4NqhzgHo/edit#gid=0)

--- a/mentors.md
+++ b/mentors.md
@@ -1,0 +1,49 @@
+# Responsibilities
+
+##Pre-course
+* Cleo
+* Jen
+* Nick
+
+## Week 1 - Toolkit
+* Cleo
+* Jen
+* Nick
+
+## Week 2 - Testing
+* Peter
+* John
+* Ewelina
+
+## Week 3 - API
+* Emily
+* Lucy
+* Ewelina
+* Nori
+
+## Week 4 - Node
+* Steve
+* Will
+* Marina
+
+## Week 5 - Node
+* Nick
+* John
+* Marko
+* Peter
+
+## Week 6 - PostgreSQL
+* Steve
+* Tom
+* Emily
+
+## Week 7 - Hapi Views
+* Will
+* Marko
+* Marina
+
+## Week 8 - Hapi Auth
+* Jen
+* Lucy
+* Emily
+* Nori


### PR DESCRIPTION
Added:

* The calendar to the readme.md
* A file containing a list of the current mentors and their assigned weeks.

Related #6 