### PR TITLE
add list of alumni who are the point of contact for FAC10

### DIFF
--- a/student-support-team.md
+++ b/student-support-team.md
@@ -4,10 +4,10 @@ Below is a list of alumni who can be considered a point of contact for each of y
 These individuals will have regular check-ins with you a few times during your course, to see how you're getting on. But you are, of course, always more than welcome to go to anyone within the community.
 
 | Alumni | Students |
-| --- | --- | --- |
+| --- | --- |
 | Jen | Oli, Alice, Martha |
 | Dan | Lucy, Zooey, Finn |
-| Nick | Alexis, Philippa | @stevehopkinson |
+| Nick | Alexis, Philippa |
 | Sohil | Samatar Joey |
 | Noga | Yvonne, Piotr |
 | Bradley | Maja, Antonio |

--- a/student-support-team.md
+++ b/student-support-team.md
@@ -7,7 +7,7 @@ These individuals will have regular check-ins with you a few times during your c
 | --- | --- | --- |
 | Jen | Oli, Alice, Martha |
 | Dan | Lucy, Zooey, Finn |
-| Nick | Alexis, Phillipa | @stevehopkinson |
+| Nick | Alexis, Philippa | @stevehopkinson |
 | Sohil | Samatar Joey |
 | Noga | Yvonne, Piotr |
 | Bradley | Maja, Antonio |

--- a/student-support-team.md
+++ b/student-support-team.md
@@ -10,5 +10,5 @@ These individuals will have regular check-ins with you a few times during your c
 | Nick | Alexis, Phillipa | @stevehopkinson |
 | Sohil | Samatar Joey |
 | Noga | Yvonne, Piotr |
-| Braldey | Maja, Antonio |
+| Bradley | Maja, Antonio |
 | Elias | Jessica, Akin |

--- a/student-support-team.md
+++ b/student-support-team.md
@@ -1,0 +1,14 @@
+# Student Support and Pastoral Care
+Below is a list of alumni who can be considered a point of contact for each of you.
+
+These individuals will have regular check-ins with you a few times during your course, to see how you're getting on. But you are, of course, always more than welcome to go to anyone within the community.
+
+| Alumni | Students |
+| --- | --- | --- |
+| Jen | Oli, Alice, Martha |
+| Dan | Lucy, Zooey, Finn |
+| Nick | Alexis, Phillipa | @stevehopkinson |
+| Sohil | Samatar Joey |
+| Noga | Yvonne, Piotr |
+| Braldey | Maja, Antonio |
+| Elias | Jessica, Akin |


### PR DESCRIPTION
It seems appropriate to add the list of "mentors" to this London-specific repo, since this contains other docs that are specific to FAC10 like the meetup rota, key people, a list of their mentors, etc.

I deliberately haven't used the word "mentors" for this pastoral care role, because we use this word to describe everyone from the cohort above them.

Happy to change any of the wording :+1: but I think it helps to make this transparent.

Based on https://github.com/foundersandcoders/london-programme/issues/209